### PR TITLE
Fix build error

### DIFF
--- a/cloudapp/src/app/settings/settings.component.ts
+++ b/cloudapp/src/app/settings/settings.component.ts
@@ -13,6 +13,7 @@ import { TroveService } from '../trove.service';
 export class SettingsComponent implements OnInit, OnDestroy {
 
   settings: any = {};
+  saving = false;
 
   constructor(private settingsService: CloudAppSettingsService, private troveService: TroveService) { }
 
@@ -30,9 +31,13 @@ export class SettingsComponent implements OnInit, OnDestroy {
   }
 
   save() {
-    this.settingsService.set(this.settings).subscribe(_ => {
-      console.debug("saving settings");
-      this.troveService.updateSettings(this.settings);
+    this.saving = true;
+    this.settingsService.set(this.settings).subscribe({
+      next: _ => {
+        console.debug("saving settings");
+        this.troveService.updateSettings(this.settings);
+      },
+      complete: () => this.saving = false
     });
   }
 }


### PR DESCRIPTION
Received this when building:
ERROR in src/app/settings/settings.component.html(1,28): Property 'saving' does not exist on type 'SettingsComponent'.

If you merge this PR, you can test with `eca build` and then create a new version and publish again.